### PR TITLE
Rubocop 0 49 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bixby: I'd buy that for a dollar!
   <img src="https://raw.githubusercontent.com/curationexperts/hycop/master/logo/murphy.jpg" alt="Murphy Sketch"/>
 </p>
 
-RuboCop Defaults for Hydra
+RuboCop Defaults for Samvera Community
 
 ## To Use This
 
@@ -30,11 +30,8 @@ Bixby is available under [the Apache 2.0 license](LICENSE.md).
 
 ## Acknowledgments
 
-This software has been developed by and is brought to you by the Hydra community.  Learn more at the
-[Project Hydra website](http://projecthydra.org/).
+This software has been developed by and is brought to you by the Samvera community.  Learn more at the
+[Samvera Community website](http://projecthydra.org/).
 
 The Alex J. Murphy sketch "logo" is courtesy of [acid_lich](https://www.instagram.com/acid_lich/), all
 rights reserved.
-
-
-

--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
   spec.name          = 'bixby'
   spec.require_paths = ['lib']
 
-  spec.version       = '0.2.0'
+  spec.version       = '0.2.1'
   spec.license       = 'Apache-2.0'
 
-  spec.add_dependency 'rubocop',       '~> 0.47'
-  spec.add_dependency 'rubocop-rspec', '~> 1.10'
+  spec.add_dependency 'rubocop',       '~> 0.49'
+  spec.add_dependency 'rubocop-rspec', '~> 1.15'
 end

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -22,15 +22,6 @@ Style/AccessorMethodName:
 Style/Alias:
   Enabled: true
 
-Style/AlignArray:
-  Enabled: true
-
-Style/AlignHash:
-  Enabled: true
-
-Style/AlignParameters:
-  Enabled: true
-
 Style/AndOr:
   Enabled: true
 
@@ -55,9 +46,6 @@ Style/BarePercentLiterals:
 Style/BlockComments:
   Enabled: true
 
-Style/BlockEndNewline:
-  Enabled: true
-
 Style/BlockDelimiters:
   Enabled: true
 
@@ -65,9 +53,6 @@ Style/BracesAroundHashParameters:
   Enabled: true
 
 Style/CaseEquality:
-  Enabled: true
-
-Style/CaseIndentation:
   Enabled: true
 
 Style/CharacterLiteral:
@@ -83,9 +68,6 @@ Style/ClassMethods:
   Enabled: true
 
 Style/ClassVars:
-  Enabled: true
-
-Style/ClosingParenthesisIndentation:
   Enabled: true
 
 Style/ColonMethodCall:
@@ -106,9 +88,6 @@ Style/CommandLiteral:
 Style/CommentAnnotation:
   Enabled: true
 
-Style/CommentIndentation:
-  Enabled: true
-
 Style/ConditionalAssignment:
   Enabled: true
 
@@ -124,9 +103,6 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
 
-Style/DotPosition:
-  Enabled: true
-
 Style/DoubleNegation:
   Enabled: true
 
@@ -136,34 +112,10 @@ Style/EachForSimpleLoop:
 Style/EachWithObject:
   Enabled: true
 
-Style/ElseAlignment:
-  Enabled: true
-
 Style/EmptyElse:
   Enabled: true
 
 Style/EmptyCaseCondition:
-  Enabled: true
-
-Style/EmptyLineBetweenDefs:
-  Enabled: true
-
-Style/EmptyLines:
-  Enabled: true
-
-Style/EmptyLinesAroundAccessModifier:
-  Enabled: true
-
-Style/EmptyLinesAroundBlockBody:
-  Enabled: true
-
-Style/EmptyLinesAroundClassBody:
-  Enabled: true
-
-Style/EmptyLinesAroundModuleBody:
-  Enabled: true
-
-Style/EmptyLinesAroundMethodBody:
   Enabled: true
 
 Style/EmptyLiteral:
@@ -175,13 +127,7 @@ Style/EmptyMethod:
 Style/EndBlock:
   Enabled: true
 
-Style/EndOfLine:
-  Enabled: true
-
 Style/EvenOdd:
-  Enabled: true
-
-Style/ExtraSpacing:
   Enabled: true
 
 Style/FileName:
@@ -191,12 +137,6 @@ Style/FileName:
     - '**/*.rake'
 
 Style/FrozenStringLiteralComment:
-  Enabled: true
-
-Style/InitialIndentation:
-  Enabled: true
-
-Style/FirstParameterIndentation:
   Enabled: true
 
 Style/FlipFlop:
@@ -229,25 +169,7 @@ Style/IfUnlessModifierOfIfUnless:
 Style/IfWithSemicolon:
   Enabled: true
 
-Style/IndentationConsistency:
-  SupportedStyles:
-    - normal
-    - rails
-  EnforcedStyle: rails
-
-Style/IndentationWidth:
-  Enabled: true
-
 Style/IdenticalConditionalBranches:
-  Enabled: true
-
-Style/IndentArray:
-  Enabled: true
-
-Style/IndentAssignment:
-  Enabled: true
-
-Style/IndentHash:
   Enabled: true
 
 Style/InfiniteLoop:
@@ -256,13 +178,7 @@ Style/InfiniteLoop:
 Style/Lambda:
   Enabled: true
 
-Style/SpaceInLambdaLiteral:
-  Enabled: true
-
 Style/LambdaCall:
-  Enabled: true
-
-Style/LeadingCommentSpace:
   Enabled: true
 
 Style/LineEndConcatenation:
@@ -283,16 +199,7 @@ Style/MethodMissing:
 Style/ModuleFunction:
   Enabled: true
 
-Style/MultilineArrayBraceLayout:
-  Enabled: true
-
 Style/MultilineBlockChain:
-  Enabled: true
-
-Style/MultilineBlockLayout:
-  Enabled: true
-
-Style/MultilineHashBraceLayout:
   Enabled: true
 
 Style/MultilineIfThen:
@@ -302,18 +209,6 @@ Style/MultilineIfModifier:
   Enabled: true
 
 Style/MultilineMemoization:
-  Enabled: true
-
-Style/MultilineMethodCallBraceLayout:
-  Enabled: true
-
-Style/MultilineMethodCallIndentation:
-  Enabled: true
-
-Style/MultilineMethodDefinitionBraceLayout:
-  Enabled: true
-
-Style/MultilineOperationIndentation:
   Enabled: true
 
 Style/MultilineTernaryOperator:
@@ -416,9 +311,6 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Enabled: true
 
-Style/RescueEnsureAlignment:
-  Enabled: true
-
 Style/RescueModifier:
   Enabled: true
 
@@ -437,71 +329,6 @@ Style/SignalException:
 Style/SingleLineMethods:
   Enabled: true
 
-Style/SpaceBeforeFirstArg:
-  Enabled: true
-
-Style/SpaceAfterColon:
-  Enabled: true
-
-Style/SpaceAfterComma:
-  Enabled: true
-
-Style/SpaceAfterMethodName:
-  Enabled: true
-
-Style/SpaceAfterNot:
-  Enabled: true
-
-Style/SpaceAfterSemicolon:
-  Enabled: true
-
-Style/SpaceBeforeBlockBraces:
-  Enabled: true
-
-Style/SpaceBeforeComma:
-  Enabled: true
-
-Style/SpaceBeforeComment:
-  Enabled: true
-
-Style/SpaceBeforeSemicolon:
-  Enabled: true
-
-Style/SpaceInsideBlockBraces:
-  Enabled: true
-
-Style/SpaceAroundBlockParameters:
-  Enabled: true
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-
-Style/SpaceAroundKeyword:
-  Enabled: true
-
-Style/SpaceAroundOperators:
-  Enabled: true
-
-Style/SpaceInsideArrayPercentLiteral:
-  Enabled: true
-
-Style/SpaceInsidePercentLiteralDelimiters:
-  Enabled: true
-
-Style/SpaceInsideBrackets:
-  Enabled: true
-
-Style/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
-Style/SpaceInsideParens:
-  Enabled: true
-
-Style/SpaceInsideRangeLiteral:
-  Enabled: true
-
-Style/SpaceInsideStringInterpolation:
-  Enabled: true
 
 Style/SpecialGlobalVars:
   Enabled: true
@@ -521,22 +348,13 @@ Style/SymbolLiteral:
 Style/SymbolProc:
   Enabled: true
 
-Style/Tab:
-  Enabled: true
-
 Style/TernaryParentheses:
-  Enabled: true
-
-Style/TrailingBlankLines:
   Enabled: true
 
 Style/TrailingCommaInArguments:
   Enabled: true
 
 Style/TrailingCommaInLiteral:
-  Enabled: true
-
-Style/TrailingWhitespace:
   Enabled: true
 
 Style/TrivialAccessors:
@@ -577,6 +395,191 @@ Style/WhileUntilModifier:
   Enabled: true
 
 Style/ZeroLengthPredicate:
+  Enabled: true
+
+#################### Layout ###############################
+
+Layout/AlignArray:
+  Enabled: true
+
+Layout/AlignHash:
+  Enabled: true
+
+Layout/AlignParameters:
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Enabled: true
+
+Layout/CaseIndentation:
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Layout/CommentIndentation:
+  Enabled: true
+
+Layout/DotPosition:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Layout/ExtraSpacing:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Layout/FirstParameterIndentation:
+  Enabled: true
+
+Layout/IndentationConsistency:
+  SupportedStyles:
+    - normal
+    - rails
+  EnforcedStyle: rails
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/IndentArray:
+  Enabled: true
+
+Layout/IndentAssignment:
+  Enabled: true
+
+Layout/IndentHash:
+  Enabled: true
+
+Layout/SpaceInLambdaLiteral:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Layout/MultilineArrayBraceLayout:
+  Enabled: true
+
+Layout/MultilineBlockLayout:
+  Enabled: true
+
+Layout/MultilineHashBraceLayout:
+  Enabled: true
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Enabled: true
+
+Layout/MultilineOperationIndentation:
+  Enabled: true
+
+Layout/RescueEnsureAlignment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
+Layout/SpaceInsideBrackets:
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
   Enabled: true
 
 #################### Metrics ###############################


### PR DESCRIPTION
Rubocop 0.49 separates "Layout" from "Style". This PR gets rid of lots of warnings that start showing up when you upgrade to Rubocop 0.49.