### PR TITLE
Include 'Capfile' in excluded filenames

### DIFF
--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -135,6 +135,8 @@ Style/FileName:
   Exclude:
     - '**/Gemfile'
     - '**/*.rake'
+    - 'Capfile'
+    - 'config/deploy/*'
 
 Style/FrozenStringLiteralComment:
   Enabled: true


### PR DESCRIPTION
Folks using Capistrano will have a 'Capfile' in their application root.   They may also define deployment stages based on the hostname of the server which may use dashes rather than snake case.