### PR TITLE
Ignore block and class length on CatalogController

### DIFF
--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -595,6 +595,8 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   Enabled: true
+  Exclude:
+    - '**/*/catalog_controller.rb'
 
 Metrics/ModuleLength:
   Enabled: true
@@ -616,6 +618,8 @@ Metrics/BlockLength:
   Enabled: true
   Exclude:
     - '**/*.gemspec'
+    - 'config/**/*'
+    - '**/*/catalog_controller.rb'
 
 Metrics/ParameterLists:
   Enabled: true


### PR DESCRIPTION
Blacklight's CatalogControllers are normally long configurations in a DSL; we don't want RuboCop to complain about the length of the class or its internal blocks.

Closes #3