### PR TITLE
Allow deeper group nesting in RSpec

### DIFF
--- a/bixby_rspec_enabled.yml
+++ b/bixby_rspec_enabled.yml
@@ -109,7 +109,7 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Enabled: true
-  Max: 3
+  Max: 5
 
 RSpec/NotToNot:
   EnforcedStyle: not_to


### PR DESCRIPTION
The reason for restricting nesting is presumably to flag complex test setups
that indicate a smell in the tested code. [Three levels are
allowed](https://github.com/backus/rubocop-rspec/pull/207#issuecomment-246208911)
to accomodate this common style:

```ruby
describe MyClass do
  describe '#a_method' do
    context 'some application state' do
      # examples
    end

    context 'other application state' do
      # examples
    end
  end
end
```

My experience has been that a slightly more complex setup in a Rails
application (particularly for model and controller specs) is more a fact of life
than a code smell. Four levels accommodates code like:

```ruby
describe MyController, type: :controller do
  context 'when logged in as admin' do
    include_context 'as admin' do

    ...
  end

  context 'when logged is as other_role' do
    include_context 'as other_role' do
    ...
  end
end
```

Using my current application as a gague, my sense is that the additional level
of nesting addresses the common cases.