### PR TITLE
Lock versions to `rubocop` 0.50.0 and `rubocop-rspec` 1.18.0

### DIFF
--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |spec|
   spec.version       = '0.3.0'
   spec.license       = 'Apache-2.0'
 
-  spec.add_dependency 'rubocop',       '~> 0.49', '<= 0.50.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.15', '<= 1.18.0'
+  spec.add_dependency 'rubocop',       '0.50.0'
+  spec.add_dependency 'rubocop-rspec', '1.18.0'
 end


### PR DESCRIPTION
We are locking the versions of rubocop dependencies for future releases of Bixby as discussed on https://github.com/samvera-labs/bixby/issues/6.

Future releases will add support for forward versions, and bump major versions when rubocop compatibility breaks.