### PR TITLE
Support newer versions of `rubocop`, `rubocop-rspec`, and Ruby

### DIFF
--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Gem::Specification.new do |spec|
   spec.authors       = ['Tom Johnson']
   spec.email         = ['tom@curationexperts.com']
@@ -12,9 +10,9 @@ Gem::Specification.new do |spec|
   spec.name          = 'bixby'
   spec.require_paths = ['lib']
 
-  spec.version       = '0.3.0'
+  spec.version       = '0.4.0'
   spec.license       = 'Apache-2.0'
 
-  spec.add_dependency 'rubocop',       '0.50.0'
-  spec.add_dependency 'rubocop-rspec', '1.18.0'
+  spec.add_dependency 'rubocop',       '~> 0.50', '<= 0.52.1'
+  spec.add_dependency 'rubocop-rspec', '~> 1.22', '<= 1.22.2'
 end

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -8,6 +8,7 @@ AllCops:
   Exclude:
     - 'db/**/*'
     - 'script/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
 
 inherit_from:
@@ -525,7 +526,10 @@ Layout/SpaceInsideArrayPercentLiteral:
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: true
 
-Layout/SpaceInsideBrackets:
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 
 Layout/SpaceInsideHashLiteralBraces:
@@ -557,7 +561,7 @@ Naming/AccessorMethodName:
 Naming/AsciiIdentifiers:
   Enabled: true
 
-Naming/BinaryOperatorParameter:
+Naming/BinaryOperatorParameterName:
   Enabled: true
 
 Naming/ClassAndModuleCamelCase:
@@ -714,7 +718,7 @@ Lint/IneffectiveAccessModifier:
 Lint/InheritException:
   Enabled: true
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Enabled: true
 
 Lint/LiteralInInterpolation:

--- a/bixby_rspec_enabled.yml
+++ b/bixby_rspec_enabled.yml
@@ -45,13 +45,6 @@ RSpec/ExpectActual:
 RSpec/ExpectOutput:
   Enabled: true
 
-RSpec/FilePath:
-  Enabled: true
-  CustomTransform:
-    RuboCop: rubocop
-    RSpec: rspec
-  IgnoreMethods: false
-
 RSpec/Focus:
   Enabled: true
 
@@ -99,10 +92,6 @@ RSpec/MessageSpies:
 
 RSpec/MultipleDescribes:
   Enabled: true
-
-RSpec/MultipleExpectations:
-  Enabled: true
-  Max: 1
 
 RSpec/NamedSubject:
   Enabled: true


### PR DESCRIPTION
Add support for Ruby 2.5.0.