### PR TITLE
Skipping node_modules directory when running cops

### DIFF
--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'script/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
+    - 'node_modules/**/*'
 
 inherit_from:
   - bixby_rails_enabled.yml


### PR DESCRIPTION
We have started adopting bixby in some of our projects and I am seeing that some of js libraries are being linted by rubocop.

As part of the default rubocop v0.63.1 configuration the node_modules directory is excluded:
https://github.com/rubocop-hq/rubocop/blob/v0.63.1/config/default.yml#L61

Would it be possible to add node_modules to the list of excluded directories? Or is this something we should do locally?