### PR TITLE
allow non-ascii characters in comments

### DIFF
--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -24,9 +24,6 @@ Style/AndOr:
 Style/ArrayJoin:
   Enabled: true
 
-Style/AsciiComments:
-  Enabled: true
-
 Style/Attr:
   Enabled: true
 


### PR DESCRIPTION
we support multi-language communities. no reason to prohibit documentation that
includes non-latin characters.