### PR TITLE
Setting rubocop-ast to ~> 0.3.0

### DIFF
--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
 
   spec.add_dependency 'rubocop', '0.85.1'
+  # Added to prevent downstream breakage; When we update the above
+  # Rubocop version, we will want to revisit this dependency.  Either
+  # changing the version range OR removing it.
+  spec.add_dependency 'rubocop-ast', '~> 0.3.0'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec'


### PR DESCRIPTION
Prior to this commit, we noticed that there were build issues with
rubocop in Hyrax:

See https://app.circleci.com/pipelines/github/samvera/hyrax/4082/workflows/35b37e66-d328-46fb-840c-d56418b54e4b/jobs/28405

```
An error occurred while Layout/LineLength cop was inspecting
/home/circleci/project/Rakefile:15:0.
```

When I ran rubocop against my local instance (with rubocop-ast 0.4.0), I
reproduced the error.  When I narrowed my Hyrax version to use
`rubocop-ast "~> 0.3.0"` this change removed the problem.

I believe with this change, we need to release 3.0.2; I'll work on that
after we review.