### PR TITLE
Upgrade to rubocop 1.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  samvera: samvera/circleci-orb@0
+  samvera: samvera/circleci-orb@1
 
 jobs:
   bundle_lint_test:
@@ -12,7 +12,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 1.17.3
+        default: 2.3.6
 
     executor:
       name: 'samvera/ruby'
@@ -21,11 +21,9 @@ jobs:
     steps:
       - samvera/cached_checkout
 
-      - samvera/bundle_for_gem:
+      - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
-          project: << parameters.project >>
-          cache_version: '2'
 
       - samvera/rubocop
 
@@ -35,21 +33,15 @@ workflows:
     jobs:
       - bundle_lint_test:
           project: bixby
-          name: ruby2-4
-          ruby_version: 2.4.10
-
-      - bundle_lint_test:
-          project: bixby
-          name: ruby2-5
-          ruby_version: 2.5.8
-
-      - bundle_lint_test:
-          project: bixby
           name: ruby2-6
-          ruby_version: 2.6.6
+          ruby_version: 2.6.9
 
       - bundle_lint_test:
           project: bixby
           name: ruby2-7
-          ruby_version: 2.7.1
+          ruby_version: 2.7.5
 
+      - bundle_lint_test:
+          project: bixby
+          name: ruby3-0
+          ruby_version: 3.0.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: bixby_default.yml

--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -15,11 +15,10 @@ Gem::Specification.new do |spec|
   spec.version       = '3.0.2'
   spec.license       = 'Apache-2.0'
 
-  spec.add_dependency 'rubocop', '0.85.1'
-  # Added to prevent downstream breakage; When we update the above
-  # Rubocop version, we will want to revisit this dependency.  Either
-  # changing the version range OR removing it.
-  spec.add_dependency 'rubocop-ast', '~> 0.3.0'
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'rubocop', '>= 1', '< 2'
+  spec.add_dependency 'rubocop-ast'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec'

--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.version       = '3.0.2'
   spec.license       = 'Apache-2.0'
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'rubocop', '>= 1', '< 2'
   spec.add_dependency 'rubocop-ast'

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -162,7 +162,7 @@ Style/MethodCallWithoutArgsParentheses:
 Style/MethodDefParentheses:
   Enabled: true
 
-Style/MethodMissingSuper:
+Style/MissingSuper:
   Enabled: true
 
 Style/MissingRespondToMissing:
@@ -795,7 +795,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -162,9 +162,6 @@ Style/MethodCallWithoutArgsParentheses:
 Style/MethodDefParentheses:
   Enabled: true
 
-Style/MissingSuper:
-  Enabled: true
-
 Style/MissingRespondToMissing:
   Enabled: true
 
@@ -724,6 +721,9 @@ Lint/LiteralInInterpolation:
   Enabled: true
 
 Lint/Loop:
+  Enabled: true
+
+Lint/MissingSuper:
   Enabled: true
 
 Lint/MultipleComparison:

--- a/bixby_rspec_enabled.yml
+++ b/bixby_rspec_enabled.yml
@@ -1,9 +1,8 @@
 ---
 require: rubocop-rspec
 
-AllCops:
-  RSpec:
-    Patterns:
+RSpec:
+  Include:
     - _spec.rb
     - "(?:^|/)spec/"
 
@@ -25,7 +24,6 @@ RSpec/DescribeMethod:
 
 RSpec/EmptyExampleGroup:
   Enabled: true
-  CustomIncludeMethods: []
 
 RSpec/ExampleLength:
   Enabled: true


### PR DESCRIPTION
Being stuck on an old version of rubocop is blocking allowing ruby 3.0+ in gems using bixby.  With the release of rubocop 1 it has adopted semantic versioning which means that new cops will not be enabled until the next major release.  This is why I've allowed any version of 1.x rubocop in the gemspec.  

I think it is worth revisiting #32 and see if there is enough energy to continue maintaining community style defaults or if the main goal of this gem has been fulfilled with the release of rubocop 1.0.