### PR TITLE
Adding the CI branch name test for `master`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,17 @@ jobs:
       ruby_version: << parameters.ruby_version >>
 
     steps:
+      - checkout
+
+      - run:
+          name: Check for 'master' branch
+          command: |
+            git fetch --all --quiet --prune --prune-tags
+            if [[ -n "$(git branch --all --list master */master)" ]]; then
+                echo "A branch named 'master' was found. Please remove it."
+                echo "$(git branch --all --list master */master)"
+            fi
+            [[ -z "$(git branch --all --list master */master)" ]]
       - samvera/cached_checkout
 
       - samvera/bundle:


### PR DESCRIPTION
This rebases and deprecates https://github.com/samvera-labs/bixby/pull/56. Resolves #50 