### PR TITLE
Reverts the changes introduced with https://github.com/samvera-labs/bixby/pull/57

### DIFF
--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -15,10 +15,13 @@ Gem::Specification.new do |spec|
   spec.version       = '3.0.2'
   spec.license       = 'Apache-2.0'
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.4'
 
-  spec.add_dependency 'rubocop', '>= 1', '< 2'
-  spec.add_dependency 'rubocop-ast'
+  spec.add_dependency 'rubocop', '0.85.1'
+  # Added to prevent downstream breakage; When we update the above
+  # Rubocop version, we will want to revisit this dependency.  Either
+  # changing the version range OR removing it.
+  spec.add_dependency 'rubocop-ast', '~> 0.3.0'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec'

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -1,7 +1,7 @@
 require: rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.4
   DisabledByDefault: true
   DisplayCopNames: true
   Exclude:
@@ -160,6 +160,9 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
+  Enabled: true
+
+Style/MethodMissingSuper:
   Enabled: true
 
 Style/MissingRespondToMissing:
@@ -723,9 +726,6 @@ Lint/LiteralInInterpolation:
 Lint/Loop:
   Enabled: true
 
-Lint/MissingSuper:
-  Enabled: true
-
 Lint/MultipleComparison:
   Enabled: true
 
@@ -795,7 +795,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/BinaryOperatorWithIdenticalOperands:
+Lint/UselessComparison:
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/bixby_rspec_enabled.yml
+++ b/bixby_rspec_enabled.yml
@@ -1,10 +1,11 @@
 ---
 require: rubocop-rspec
 
-RSpec:
-  Include:
-    - _spec.rb
-    - "(?:^|/)spec/"
+AllCops:
+  RSpec:
+    Patterns:
+      - _spec.rb
+      - "(?:^|/)spec/"
 
 RSpec/AnyInstance:
   Enabled: true
@@ -24,6 +25,7 @@ RSpec/DescribeMethod:
 
 RSpec/EmptyExampleGroup:
   Enabled: true
+  CustomIncludeMethods: []
 
 RSpec/ExampleLength:
   Enabled: true


### PR DESCRIPTION
I am extremely sorry @cjcolvar, I suspect that I prematurely merged https://github.com/samvera-labs/bixby/pull/57 in error. I have preserved the https://github.com/samvera-labs/bixby/tree/rubocop1 branch, and following the merging of this, I can reopen this.