### PR TITLE
Make new issue link work now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ further details.
 ### Reporting Issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a [Github issue](https://github.com/samvera/{{library}}/issues/) by:
+* Submit a [Github issue](https://github.com/samvera-labs/bixby/issues/) by:
   * Clearly describing the issue
     * Provide a descriptive summary
     * Explain the expected behavior


### PR DESCRIPTION
Fix link to have name of this gem and use `samvera-labs` since it hasn't been promoted yet.