### PR TITLE
Upgrade to Rubocop 1.x

### DIFF
--- a/bixby.gemspec
+++ b/bixby.gemspec
@@ -15,13 +15,10 @@ Gem::Specification.new do |spec|
   spec.version       = '3.0.2'
   spec.license       = 'Apache-2.0'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
-  spec.add_dependency 'rubocop', '0.85.1'
-  # Added to prevent downstream breakage; When we update the above
-  # Rubocop version, we will want to revisit this dependency.  Either
-  # changing the version range OR removing it.
-  spec.add_dependency 'rubocop-ast', '~> 0.3.0'
+  spec.add_dependency 'rubocop', '>= 1', '< 2'
+  spec.add_dependency 'rubocop-ast'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec'

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -603,12 +603,13 @@ Naming/VariableName:
 
 Naming/VariableNumber:
   Enabled: true
+  CheckSymbols: false
 
 #################### Metrics ###############################
 
 Metrics/AbcSize:
   Enabled: true
-  Max: 28
+  Max: 32
 
 Metrics/BlockNesting:
   Enabled: true
@@ -623,6 +624,7 @@ Metrics/ModuleLength:
 
 Metrics/CyclomaticComplexity:
   Enabled: true
+  Max: 10
 
 Metrics/MethodLength:
   Enabled: true
@@ -640,6 +642,7 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Enabled: true
+  Max: 11
 
 #################### Lint ##################################
 ### Warnings

--- a/bixby_default.yml
+++ b/bixby_default.yml
@@ -1,7 +1,7 @@
 require: rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   DisabledByDefault: true
   DisplayCopNames: true
   Exclude:
@@ -160,9 +160,6 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
-  Enabled: true
-
-Style/MethodMissingSuper:
   Enabled: true
 
 Style/MissingRespondToMissing:
@@ -726,6 +723,9 @@ Lint/LiteralInInterpolation:
 Lint/Loop:
   Enabled: true
 
+Lint/MissingSuper:
+  Enabled: true
+
 Lint/MultipleComparison:
   Enabled: true
 
@@ -795,7 +795,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/bixby_rspec_enabled.yml
+++ b/bixby_rspec_enabled.yml
@@ -1,11 +1,10 @@
 ---
 require: rubocop-rspec
 
-AllCops:
-  RSpec:
-    Patterns:
-      - _spec.rb
-      - "(?:^|/)spec/"
+RSpec:
+  Include:
+    - _spec.rb
+    - "(?:^|/)spec/"
 
 RSpec/AnyInstance:
   Enabled: true
@@ -25,7 +24,6 @@ RSpec/DescribeMethod:
 
 RSpec/EmptyExampleGroup:
   Enabled: true
-  CustomIncludeMethods: []
 
 RSpec/ExampleLength:
   Enabled: true


### PR DESCRIPTION
This PR reopens #57 and adds another commit that adjusts the thresholds of 3 cops and a configuration option of another based upon running the original PR against Hyrax's main branch (see https://gist.github.com/cjcolvar/4185fa40bd88ac7ec2203d1a78c94bd2 and https://github.com/samvera/hyrax/pull/5478).  

This change would probably be a major release given the upgrade of rubocop, the dropping of ruby 2.4, and the fact that downstream repos will probably have to fix some autocorrectable violations when upgrading.